### PR TITLE
Warnings fixup

### DIFF
--- a/include/FSWebServerLib.h
+++ b/include/FSWebServerLib.h
@@ -181,7 +181,7 @@ public:
     void begin(FS* fs) ;                        // esp8266/esp32 flash file system
 #endif
     void handle();
-    const char* getHostName();
+	const String getHostName();
 	AsyncFSWebServer& setJSONCallback(JSON_CALLBACK_SIGNATURE);
 	AsyncFSWebServer& setRESTCallback(REST_CALLBACK_SIGNATURE);
 	AsyncFSWebServer& setPOSTCallback(POST_CALLBACK_SIGNATURE);

--- a/include/main.h
+++ b/include/main.h
@@ -16,7 +16,7 @@
 #define MIN 60  // 60 secs
 
 
-#define LOCALHOST '127.0.0.1'
+#define LOCALHOST "127.0.0.1"
 #define UDP_PORT  40001
 
 

--- a/src/FSWebServerLib.cpp
+++ b/src/FSWebServerLib.cpp
@@ -2398,9 +2398,8 @@ bool AsyncFSWebServer::checkAuth(AsyncWebServerRequest *request) {
 
 }
 
-const char* AsyncFSWebServer::getHostName() {
-	String hostname = _sysConfig.deviceName+"_"+_sysConfig.deviceSerial;
-	return hostname.c_str();
+const String AsyncFSWebServer::getHostName() {
+	return _sysConfig.deviceName+"_"+_sysConfig.deviceSerial;
 }
 
 AsyncFSWebServer& AsyncFSWebServer::setJSONCallback(JSON_CALLBACK_SIGNATURE) {

--- a/src/eertos.cpp
+++ b/src/eertos.cpp
@@ -5,7 +5,7 @@
  *      Author: Sam
  */
 #include <stdint.h>
-#include "EERTOS.h"
+#include "eertos.h"
 
 //Пустая процедура - простой ядра.
 void  Idle_task(void) { }

--- a/src/udphelper.cpp
+++ b/src/udphelper.cpp
@@ -21,7 +21,7 @@
 #include "FSWebServerLib.h"
 #include "debug.h"
 
-IPAddress responseIp (LOCALHOST);
+IPAddress responseIp ((const unsigned char *) LOCALHOST);
 AsyncUDP udp_broadcast;
 AsyncUDP udp_listen;
 


### PR DESCRIPTION
There was several warnings by compiler:
1. ```#include EERTOS.h``` has to be ```#include eertos.h``` because of case sensitive OS, like Linux
2. LOCALHOST macro was char type, not char *. Changed to string constant and use cast in the macro call
3.  Used local variable after String concatenation. After returning from function you will loose String because of destructor. So you will get pointer (const char *) to the memory segment, that was market as free int the heap. Usage of String will solve potential problems.