### PR TITLE
Clang support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,43 @@
+---
+BasedOnStyle: Google
+
+# How much whitespace?
+UseTab: Always
+TabWidth: 4
+IndentWidth: 4
+ContinuationIndentWidth: 4
+LineEnding: DeriveLF
+
+SpacesBeforeTrailingComments: 1
+
+# Line things up
+AccessModifierOffset: -4  # outdent `public:`, etc
+
+DerivePointerAlignment: false
+PointerAlignment: Right   # char *foo, char &bar
+
+AlignAfterOpenBracket: true
+AlignConsecutiveAssignments:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: false
+AlignConsecutiveDeclarations: true
+
+AllowShortIfStatementsOnASingleLine: false
+
+# Braces
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+AllowShortFunctionsOnASingleLine: Inline
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterStruct: true
+  AfterClass: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterControlStatement: true
+  AfterNamespace: false
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,5 +63,15 @@
         "sstream": "cpp",
         "thread": "cpp"
     },
-    "C_Cpp.errorSquiggles": "disabled"
+    "C_Cpp.errorSquiggles": "disabled",
+    "editor.formatOnSaveMode": "modifications",
+    "editor.formatOnSave": true,
+    "editor.formatOnType": true,
+    "editor.wordWrapColumn": 120,
+    "editor.rulers": [
+        {
+            "color": "#FF0000",
+            "column": 120
+        }
+    ]
 }

--- a/include/FSWebServerLib.h
+++ b/include/FSWebServerLib.h
@@ -181,7 +181,7 @@ public:
     void begin(FS* fs) ;                        // esp8266/esp32 flash file system
 #endif
     void handle();
-    const char* getHostName();
+	const String getHostName();
 	AsyncFSWebServer& setJSONCallback(JSON_CALLBACK_SIGNATURE);
 	AsyncFSWebServer& setRESTCallback(REST_CALLBACK_SIGNATURE);
 	AsyncFSWebServer& setPOSTCallback(POST_CALLBACK_SIGNATURE);

--- a/include/main.h
+++ b/include/main.h
@@ -16,7 +16,7 @@
 #define MIN 60  // 60 secs
 
 
-#define LOCALHOST '127.0.0.1'
+#define LOCALHOST "127.0.0.1"
 #define UDP_PORT  40001
 
 

--- a/src/FSWebServerLib.cpp
+++ b/src/FSWebServerLib.cpp
@@ -2398,9 +2398,8 @@ bool AsyncFSWebServer::checkAuth(AsyncWebServerRequest *request) {
 
 }
 
-const char* AsyncFSWebServer::getHostName() {
-	String hostname = _sysConfig.deviceName+"_"+_sysConfig.deviceSerial;
-	return hostname.c_str();
+const String AsyncFSWebServer::getHostName() {
+	return _sysConfig.deviceName+"_"+_sysConfig.deviceSerial;
 }
 
 AsyncFSWebServer& AsyncFSWebServer::setJSONCallback(JSON_CALLBACK_SIGNATURE) {

--- a/src/eertos.cpp
+++ b/src/eertos.cpp
@@ -5,7 +5,7 @@
  *      Author: Sam
  */
 #include <stdint.h>
-#include "EERTOS.h"
+#include "eertos.h"
 
 //Пустая процедура - простой ядра.
 void  Idle_task(void) { }

--- a/src/udphelper.cpp
+++ b/src/udphelper.cpp
@@ -21,7 +21,7 @@
 #include "FSWebServerLib.h"
 #include "debug.h"
 
-IPAddress responseIp (LOCALHOST);
+IPAddress responseIp ((const unsigned char *) LOCALHOST);
 AsyncUDP udp_broadcast;
 AsyncUDP udp_listen;
 


### PR DESCRIPTION
Использование линтера поможет систематизировать отображение кода, чтобы он не был похож на монстра Франкенштейна. Я залил правила, которые использую в своей ежедневной работе и к которым давно привык.
Дело вкуса, конечно. И можно обсудить.