### PR TITLE
Add common [env] section to the platformio.ini file

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,43 +10,38 @@
 [platformio]
 data_dir = ./data
 
-[env:espwroom32]
-platform = espressif32
+; Common settings will be applied to all env
+[env]
 framework = arduino
-board = upesy_wroom
 monitor_speed = 115200
-upload_speed = 921600
-lib_deps =
-	bblanchon/ArduinoJson@^7.3.1
-	tzapu/WiFiManager@^2.0.17
-	esphome/AsyncTCP-esphome@^2.1.4
-	esphome/ESPAsyncWebServer-esphome@^3.3.0
-
-[env:esp32cam]
-platform = espressif32
-framework = arduino
-board = esp32cam
-monitor_speed = 115200
-monitor_dtr = 1
-monitor_rts = 0
-monitor_filters = esp32_exception_decoder
 upload_speed = 921600
 board_build.partitions =
 lib_deps =
 	bblanchon/ArduinoJson@^7.3.1
 	tzapu/WiFiManager@^2.0.17
-	esphome/AsyncTCP-esphome@^2.1.4
 	esphome/ESPAsyncWebServer-esphome@^3.3.0
+
+[env:espwroom32]
+platform = espressif32
+board = upesy_wroom
+lib_deps =
+	${env.lib_deps}
+	esphome/AsyncTCP-esphome@^2.1.4
+
+[env:esp32cam]
+platform = espressif32
+board = esp32cam
+monitor_dtr = 1
+monitor_rts = 0
+monitor_filters = esp32_exception_decoder
+lib_deps =
+	${env.lib_deps}
+	esphome/AsyncTCP-esphome@^2.1.4
 
 [env:d1_mini_pro]
 platform = espressif8266
 board = d1_mini
-framework = arduino
-monitor_speed = 115200
-upload_speed = 921600
 lib_deps =
-	bblanchon/ArduinoJson@^7.3.1
-	tzapu/WiFiManager@^2.0.17
+	${env.lib_deps}
 	esphome/ESPAsyncTCP-esphome@^2.0.0
-	esphome/ESPAsyncWebServer-esphome@^3.3.0
 	me-no-dev/ESPAsyncUDP@0.0.0-alpha+sha.697c75a025


### PR DESCRIPTION
There is common section, you can use to set common options for all the platforms. e.g. serial speed or lib.depts