### PR TITLE
Esp 32 super mini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -45,3 +45,15 @@ lib_deps =
 	${env.lib_deps}
 	esphome/ESPAsyncTCP-esphome@^2.0.0
 	me-no-dev/ESPAsyncUDP@0.0.0-alpha+sha.697c75a025
+
+; ESP32-C3 Super Mini
+[env:esp32-c3-devkitm-1]
+platform = espressif32
+board = esp32-c3-devkitm-1
+monitor_speed = 115200
+build_flags=
+	-DARDUINO_USB_MODE=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
+lib_deps =
+	${env.lib_deps}
+	esphome/AsyncTCP-esphome@^2.1.4


### PR DESCRIPTION
Добавил конфиг для маленьких и недорогих модулей на базе ESP32-C3.
Из-за того, что у него UART эмулируется через USB самого чипа (без внешней микросхемы), то при прошивке на Linux может меняться порт.
Поэтому я прописал Custom порт по id, чтобы работало:
`/dev/serial/by-id/usb-Espressif_USB_JTAG_serial_debug_unit_20:6E:F1:69:CE:2C-if00`